### PR TITLE
fix: better handling of boolean inputs

### DIFF
--- a/.github/actions/dotnet/test/action.yml
+++ b/.github/actions/dotnet/test/action.yml
@@ -21,12 +21,12 @@ runs:
   using: composite
   steps:
     - name: Run tests with coverage report
-      if: ${{ inputs.GENERATE_CODE_COVERAGE == 'true' }}
+      if: ${{ inputs.GENERATE_CODE_COVERAGE == 'true' || inputs.GENERATE_CODE_COVERAGE == true }}
       shell: 'bash'
       run: |
         params=()
         [[ -n "${{ inputs.EXCLUDE_FILES }}" ]] && params+=(-p:ExcludeByFile=\"${{ inputs.EXCLUDE_FILES }}\")
-        
+
         dotnet test --no-build \
           --logger trx -p:CollectCoverage=true \
           -p:CoverletOutputFormat=opencover \

--- a/.github/actions/sonar/analyze/action.yml
+++ b/.github/actions/sonar/analyze/action.yml
@@ -33,7 +33,7 @@ runs:
 
     steps:
       - name: Download coverage artifact
-        if: ${{ inputs.DOWNLOAD_ARTIFACT == 'true' }}
+        if: ${{ inputs.DOWNLOAD_ARTIFACT == 'true' || inputs.DOWNLOAD_ARTIFACT == true }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.ARTIFACT_FILENAME }}

--- a/.github/workflows/dotnet-workflow-common.yml
+++ b/.github/workflows/dotnet-workflow-common.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run tests
         uses: zupit-it/pipeline-templates/.github/actions/dotnet/test@v1.27.3
-        if: ${{ inputs.RUN_TESTS == 'true' }}
+        if: ${{ inputs.RUN_TESTS == 'true' || inputs.RUN_TESTS == true }}
         with:
           WORKING_DIRECTORY: ${{ inputs.WORKING_DIRECTORY }}
           GENERATE_CODE_COVERAGE: false

--- a/.github/workflows/dotnet-workflow-common.yml
+++ b/.github/workflows/dotnet-workflow-common.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Lint
         uses: zupit-it/pipeline-templates/.github/actions/dotnet/lint@v1.27.3
-        if: ${{ inputs.RUN_LINT == 'true' }}
+        if: ${{ inputs.RUN_LINT == 'true' || inputs.RUN_LINT == true }}
         with:
           WORKING_DIRECTORY: ${{ inputs.WORKING_DIRECTORY }}
 


### PR DESCRIPTION
I noticed dotnet tests were not running on pull-requests in Zumetrics and Platone projects (see [ZUME-8](https://github.com/zupit-it/zupit-metrics/pull/2)):
- https://github.com/zupit-it/data-discovery-platone/actions/runs/15182988804/job/42696700165
- https://github.com/zupit-it/zupit-metrics/actions/runs/15182467370/job/42694926821
![image](https://github.com/user-attachments/assets/084980e3-c527-4441-a08b-721e9f010841)

This is because `inputs.RUN_TESTS` isn't set and the default value `true` is a boolean but in `pipeline-templates\.github\workflows\dotnet-workflow-common.yml` the if condition handles only string (`if: ${{ inputs.RUN_LINT == 'true' }}`).

I found a similar bug in two more .yml files.

[ZUME-8]: https://zupit-pro.atlassian.net/browse/ZUME-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ