### PR TITLE
feat: add custom db image name

### DIFF
--- a/.github/workflows/django-step-lint-check.yml
+++ b/.github/workflows/django-step-lint-check.yml
@@ -42,6 +42,10 @@ on:
         required: false
         type: string
         default: "latest"
+      DB_POSTGRES_IMAGE_NAME:
+        required: false
+        type: string
+        default: "postgres"
 
 env: "${{secrets}}"
 
@@ -59,7 +63,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:${{ inputs.DB_POSTGRES_VERSION }}
+        image: ${{ format('{0}:{1}', inputs.DB_POSTGRES_IMAGE_NAME, inputs.DB_POSTGRES_VERSION) }}
         env:
           POSTGRES_USER: django-runner
           POSTGRES_PASSWORD: django-runner

--- a/.github/workflows/django-step-tests.yml
+++ b/.github/workflows/django-step-tests.yml
@@ -47,6 +47,10 @@ on:
         required: false
         type: string
         default: "latest"
+      DB_POSTGRES_IMAGE_NAME:
+        required: false
+        type: string
+        default: "postgres"
 
 env: "${{secrets}}"
 
@@ -64,7 +68,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:${{ inputs.DB_POSTGRES_VERSION }}
+        image: ${{ format('{0}:{1}', inputs.DB_POSTGRES_IMAGE_NAME, inputs.DB_POSTGRES_VERSION) }}
         env:
           POSTGRES_USER: django-runner
           POSTGRES_PASSWORD: django-runner

--- a/.github/workflows/django-workflow-common.yml
+++ b/.github/workflows/django-workflow-common.yml
@@ -64,6 +64,10 @@ on:
         required: false
         type: string
         default: "latest"
+      DB_POSTGRES_IMAGE_NAME:
+        required: false
+        type: string
+        default: "postgres"
 env:
   CHECK_DIR: ${{ inputs.WORKING_DIRECTORY }}
 
@@ -110,6 +114,7 @@ jobs:
       ENABLE_LFS: ${{inputs.ENABLE_LFS}}
       LFS_REPO_PATH: ${{inputs.LFS_REPO_PATH}}
       DB_POSTGRES_VERSION: ${{inputs.DB_POSTGRES_VERSION}}
+      DB_POSTGRES_IMAGE_NAME: ${{inputs.DB_POSTGRES_IMAGE_NAME}}
     secrets: inherit
 
   django-tests:
@@ -128,6 +133,7 @@ jobs:
       LFS_REPO_PATH: ${{inputs.LFS_REPO_PATH}}
       COVERAGE_THRESHOLD: ${{inputs.COVERAGE_THRESHOLD}}
       DB_POSTGRES_VERSION: ${{inputs.DB_POSTGRES_VERSION}}
+      DB_POSTGRES_IMAGE_NAME: ${{inputs.DB_POSTGRES_IMAGE_NAME}}
     secrets: inherit
 
   jobs-succeded:


### PR DESCRIPTION
Problema
Nei workflow Django l’immagine del DB è fissata a `postgres:<version>`. Questo impedisce l’uso di estensioni non incluse (es. pgvector)

Soluzione
Rendo configurabile il nome dell’immagine Postgres tramite un nuovo input `DB_POSTGRES_IMAGE_NAME` (default `postgres`). L’immagine diventa `<image_name>:<version>`.

Esempi
- default invariato: `postgres:latest`
- pgvector: `DB_POSTGRES_IMAGE_NAME=pgvector/pgvector`, `DB_POSTGRES_VERSION=pg14`

Backward compatible: se non impostato, non cambia nulla.
