### PR TITLE
ci: move cheap jobs back to warpbuild runners

### DIFF
--- a/.github/workflows/azure-webapp-code-deploy.yml
+++ b/.github/workflows/azure-webapp-code-deploy.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for all jobs. workdir-has-changes and jobs-succeeded match the cheap-pattern profiled in sibling templates; deploy mirrors dotnet-step-azure-webapp-build-and-deploy.yml's deploy job (p95 CPU 22% on 4x) - the only work is the Azure App Service publish action."
       RUNNERS_CONTAINER_GROUP:
         required: false
@@ -59,9 +59,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -88,9 +86,7 @@ jobs:
   deploy:
     needs: workdir-has-changes
     if: ${{ !inputs.CHECK_WORKDIR_CHANGES || (needs.workdir-has-changes.outputs.changes-detected == 'true' && (inputs.CHECK_CHANGES_BY_JOBS == 'all' || contains(fromJson(inputs.CHECK_CHANGES_BY_JOBS), github.job)))}}
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     env: ${{ fromJson(inputs.ENV_VARIABLES) }}
     environment: ${{ inputs.RELEASE_ENVIRONMENT }}
     container:
@@ -126,9 +122,7 @@ jobs:
 
   jobs-succeeded:
     needs: deploy
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: deploy didn't fail."

--- a/.github/workflows/conventional-commits-step-lint.yml
+++ b/.github/workflows/conventional-commits-step-lint.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
       RUNNERS_CONTAINER_GROUP:
         required: false
         type: string
@@ -15,9 +15,7 @@ on:
 jobs:
   lint-pr:
     name: Lint PR
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/conventional-commits-step-release.yml
+++ b/.github/workflows/conventional-commits-step-release.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
       RUNNERS_CONTAINER_GROUP:
         required: false
         type: string
@@ -21,9 +21,7 @@ on:
 jobs:
   release:
     name: release
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/django-workflow-common.yml
+++ b/.github/workflows/django-workflow-common.yml
@@ -22,7 +22,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). Both match cheap patterns profiled at p95 CPU < 13% on 4x in sibling templates."
       # NOTE: RUN_ON_BUILD now drives django-step-tests only. Lint moved to
       # RUN_ON_LINT (see below) after the May-2026 runner-sizing sweep showed
@@ -114,9 +114,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -220,9 +218,7 @@ jobs:
 
   jobs-succeded:
     needs: ["django-lint-check", "django-lint-check-mssql", "django-tests", "django-tests-mssql"]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: django-lint-check, django-tests didn't fail."

--- a/.github/workflows/docker-step-delete-images.yml
+++ b/.github/workflows/docker-step-delete-images.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
       RUNNERS_CONTAINER_GROUP:
         required: false
         type: string
@@ -32,9 +32,7 @@ on:
 jobs:
   to-lowercase-repository-name:
     name: "Get repository name to lowercase"
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
 
     outputs:
       REPOSITORY_NAME: ${{ steps.string.outputs.lowercase }}
@@ -47,9 +45,7 @@ jobs:
 
   clean-untagged-images:
     name: "Delete untagged images ${{ needs.to-lowercase-repository-name.outputs.REPOSITORY_NAME }}/${{ inputs.IMAGE_NAME }}"
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     needs: [to-lowercase-repository-name]
     steps:
       - name: "Delete untagged images ${{ needs.to-lowercase-repository-name.outputs.REPOSITORY_NAME }}*"
@@ -66,9 +62,7 @@ jobs:
 
   clean-staging-tagged-images:
     name: "Delete staging tagged images ${{ github.event.repository.name }}/${{ inputs.IMAGE_NAME }}"
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     needs: [clean-untagged-images]
     steps:
       - name: Delete tagged images ${{ inputs.IMAGE_NAME }}
@@ -85,9 +79,7 @@ jobs:
   clean-production-tagged-images:
     name: "Delete production tagged images ${{ github.event.repository.name }}/${{ inputs.IMAGE_NAME }}"
     needs: [clean-untagged-images]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     steps:
       - name: Delete tagged images ${{ inputs.IMAGE_NAME }}
         uses: vlaurin/action-ghcr-prune@v0.6.0

--- a/.github/workflows/dotnet-step-azure-webapp-build-and-deploy.yml
+++ b/.github/workflows/dotnet-step-azure-webapp-build-and-deploy.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, deploy, jobs-succeded). p95 CPU < 25% on 4x in profiling."
       RUN_ON_BUILD:
         required: false
@@ -78,9 +78,7 @@ env: "${{secrets}}"
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -148,9 +146,7 @@ jobs:
 
   deploy:
     if: ${{ !inputs.CHECK_WORKDIR_CHANGES || (needs.workdir-has-changes.outputs.changes-detected == 'true' && (inputs.CHECK_CHANGES_BY_JOBS == 'all' || contains(fromJson(inputs.CHECK_CHANGES_BY_JOBS), github.job)))}}
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     env: ${{ fromJson(inputs.ENV_VARIABLES) }}
     environment: ${{ inputs.RELEASE_ENVIRONMENT }}
     container:
@@ -191,9 +187,7 @@ jobs:
 
   jobs-succeded:
     needs: [build, deploy]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always() }}
     steps:
       - name: "Check if jobs succeeded"

--- a/.github/workflows/dotnet-workflow-common.yml
+++ b/.github/workflows/dotnet-workflow-common.yml
@@ -12,7 +12,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). p95 CPU < 12% on 4x in profiling."
       RUN_ON_BUILD:
         required: false
@@ -61,9 +61,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -132,9 +130,7 @@ jobs:
 
   jobs-succeded:
     needs: dotnet-common
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: dotnet-common didn't fail."

--- a/.github/workflows/jira-add-description-to-pr.yml
+++ b/.github/workflows/jira-add-description-to-pr.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
       RUNNERS_CONTAINER_GROUP:
         required: false
         type: string
@@ -20,9 +20,7 @@ on:
 
 jobs:
   jira-description:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
 
     steps:
       - uses: cakeinpanic/jira-description-action@v0.4.0

--- a/.github/workflows/jira-step-create-todo-issues.yml
+++ b/.github/workflows/jira-step-create-todo-issues.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
       RUNNERS_CONTAINER_GROUP:
         required: false
         type: string
@@ -35,9 +35,7 @@ on:
 
 jobs:
   create-todo-jira-issue:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
 
     steps:
       - name: Login to Jira

--- a/.github/workflows/jira-step-move-issue.yml
+++ b/.github/workflows/jira-step-move-issue.yml
@@ -9,7 +9,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-x64-2x"
       RUNNERS_CONTAINER_GROUP:
         required: false
         type: string
@@ -27,9 +27,7 @@ on:
 
 jobs:
   move-jira-issue:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container:
       image: ${{ inputs.DIND_IMAGE }}
 

--- a/.github/workflows/node-step-azure-storage-build-and-deploy.yml
+++ b/.github/workflows/node-step-azure-storage-build-and-deploy.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, node-deploy-azure-storage, jobs-succeded). p95 CPU 10-22% on 4x in profiling."
       RUN_ON_BUILD:
         required: false
@@ -116,9 +116,7 @@ env: "${{secrets}}"
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -188,9 +186,7 @@ jobs:
   node-deploy-azure-storage:
     needs: [workdir-has-changes, build-node-project]
     if: ${{ !inputs.CHECK_WORKDIR_CHANGES || (needs.workdir-has-changes.outputs.changes-detected == 'true' && (inputs.CHECK_CHANGES_BY_JOBS == 'all' || contains(fromJson(inputs.CHECK_CHANGES_BY_JOBS), github.job)))}}
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     env: ${{ fromJson(inputs.ENV_VARIABLES) }}
     environment: ${{ inputs.RELEASE_ENVIRONMENT }}
     container:
@@ -234,9 +230,7 @@ jobs:
 
   jobs-succeded:
     needs: [build-node-project, node-deploy-azure-storage]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always() }}
     steps:
       - name: "Check if jobs succeeded"

--- a/.github/workflows/node-workflow-common.yml
+++ b/.github/workflows/node-workflow-common.yml
@@ -29,7 +29,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). p95 CPU < 12% on 4x in profiling."
       RUN_ON_BUILD:
         required: false
@@ -66,9 +66,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -122,9 +120,7 @@ jobs:
 
   jobs-succeded:
     needs: ["lint-check-build", "cypress-run"]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: lint-check-build, cypress-run didn't fail."

--- a/.github/workflows/python-workflow-common.yml
+++ b/.github/workflows/python-workflow-common.yml
@@ -18,7 +18,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). Both match cheap patterns profiled at p95 CPU < 13% on 4x in sibling templates."
       # RUN_ON_LINT: python-step-lint-check only runs `pip install` + `flake8`
       # + `black --check` - the same CPU-light lint profile django/springboot
@@ -72,9 +72,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -115,9 +113,7 @@ jobs:
 
   jobs-succeded:
     needs: ["django-lint-check"]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: django-lint-check didn't fail."

--- a/.github/workflows/sonar-step-analyze.yml
+++ b/.github/workflows/sonar-step-analyze.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). p95 CPU < 13% on 4x in reference-project profiling."
       RUN_ON_ANALYZE:
         required: false
@@ -59,9 +59,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -115,9 +113,7 @@ jobs:
 
   jobs-succeded:
     needs: ["sonar-analyze"]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: sonar-analyze didn't fail."

--- a/.github/workflows/sonar-step-dotnet-analyze.yml
+++ b/.github/workflows/sonar-step-dotnet-analyze.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). p95 CPU < 13% on 4x in profiling."
       RUN_ON_ANALYZE:
         required: false
@@ -81,9 +81,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -171,9 +169,7 @@ jobs:
 
   jobs-succeded:
     needs: sonar-analyze
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: sonar-analyze didn't fail."

--- a/.github/workflows/sonar-step-flutter-analyze.yml
+++ b/.github/workflows/sonar-step-flutter-analyze.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). Both match cheap patterns profiled at p95 CPU < 13% on 4x in sibling templates."
       # RUN_ON_ANALYZE: the Flutter sonar-analyze job only downloads the coverage
       # artifact and runs bare `sonar-scanner` + quality-gate wait - no flutter
@@ -70,9 +70,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -126,9 +124,7 @@ jobs:
 
   jobs-succeded:
     needs: ["sonar-analyze"]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: sonar-analyze didn't fail."

--- a/.github/workflows/sonar-step-springboot-analyze.yml
+++ b/.github/workflows/sonar-step-springboot-analyze.yml
@@ -6,7 +6,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). Both match cheap patterns profiled at p95 CPU < 13% on 4x in sibling templates."
       # RUN_ON_ANALYZE: the Spring Boot sonar-analyze job runs
       # `./mvnw initialize ...sonar:sonar` - only the Maven `initialize` phase,
@@ -85,9 +85,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -147,9 +145,7 @@ jobs:
 
   jobs-succeded:
     needs: ["sonar-analyze"]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: sonar-analyze didn't fail."

--- a/.github/workflows/springboot-workflow-common.yml
+++ b/.github/workflows/springboot-workflow-common.yml
@@ -55,7 +55,7 @@ on:
       RUN_ON:
         required: false
         type: string
-        default: "zupit-agents"
+        default: "warp-ubuntu-latest-arm64-2x"
         description: "Runner for cheap jobs (workdir-has-changes, jobs-succeded). Both match cheap patterns profiled at p95 CPU < 13% on 4x in sibling templates."
       # NOTE: RUN_ON_BUILD now drives springboot-step-tests and
       # springboot-step-tests-mysql only. Lint moved to RUN_ON_LINT (see below)
@@ -86,9 +86,7 @@ env:
 
 jobs:
   workdir-has-changes:
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     container: buildpack-deps:24.04-scm
     outputs:
       changes-detected: ${{ steps.filter.outputs.changes-detected }}
@@ -163,9 +161,7 @@ jobs:
 
   jobs-succeded:
     needs: ["springboot-lint-check", "springboot-tests", "springboot-tests-mysql"]
-    runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+    runs-on: ${{ inputs.RUN_ON }}
     if: ${{ always()}}
     steps:
       - name: "Jobs: springboot-lint-check, springboot-tests, springboot-tests-mysql didn't fail."

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ In addition, it is possible to specify this optional input:
 - **SHELL**: The shell type to use. By default, it is **bash**.
 - **PROJECT**: The project to use when running npm scripts. If set, the executed npm script will be `{PROJECT}:{SCRIPT_NAME}` instead of `{SCRIPT_NAME}`.
 - **CHECKOUT_REF**: The ref of the branch/tag to check out before running the build. See the ref parameter of the [checkout action](https://github.com/actions/checkout). By default, it is `''`.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -983,8 +983,8 @@ In addition, it is possible to specify these optional inputs:
 - **TIMEOUT**: Used for tests, if the tests take more than the given time in minutes, Github stops forcefully the workflow. By default, it is **30**.
 - **RUN**: Whether to run all the jobs inside workflows or not. This is useful when you want to skip checks since the code didn't change. By default, it is **true**.
 - **PROJECT**: The project to use when running npm scripts. If set, the executed npm script will be `{PROJECT}:{SCRIPT_NAME}` instead of `{SCRIPT_NAME}`.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1079,8 +1079,8 @@ It requires these inputs:
 
 In addition, it is possible to specify these optional inputs:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 - **REGISTRY_URL**: The registry url where to push the Docker image. By default, it is **ghcr.io**.
 - **REGISTRY_USER**: The registry url where to push the Docker image.
   By default, it is the GitHub variable **github.actor**, the user who started the workflow. If you need a different user, remember to override the **GITHUB_TOKEN** secret.
@@ -1126,8 +1126,8 @@ Also, these input parameters are optional:
 - **IMAGE**: the docker image to use when running the node build. By default, it is **ubuntu:23.04**.
 - **AZURE_CLI_IMAGE**: the docker image to use when running the deployment to Azure Storage. By default, it is **mcr.microsoft.com/azure-cli:2.69.0**.
 - **TDNF_PACKAGE_MANAGER_INSTALL_TAR**: a boolean that determines whether the tar package should be installed. Default is **true**.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1181,8 +1181,8 @@ It requires these inputs:
 
 In addition, it is possible to specify this optional input:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 - **COVERAGE_ARTIFACT_NAME**: The artifact's name for the _coverage-django.xml_ file. By default, it is **coverage-django.xml**.
 - **RUN**: Whether to run all the jobs inside workflows or not. This is useful when you want to skip checks since the code didn't change. By default, it is **true**.
 - **DJANGO_MIGRATIONS_CHECK_APPS**: The Django apps on which to run migration checks.
@@ -1284,7 +1284,7 @@ In addition, it is possible to specify this optional input:
 - **MAVEN_USER_HOME**: T RUN_ON:
   required: false
   type: string
-  default: 'zupit-agents'
+  default: 'warp-ubuntu-latest-arm64-2x'
   RUNNERS_CONTAINER_GROUP:
   required: false
   type: string
@@ -1292,8 +1292,8 @@ In addition, it is possible to specify this optional input:
 - **EXTRA_MAVEN_ARGS**: Additional arguments for Maven. By default, it is **""**.
 - **USE_CI_POSTGRES**: Whether to use Postgres for tests or not. If enabled, it injects the connection string to the DB for tests. By default, it is **true**.
 - **RUN**: Whether to run all the jobs inside workflows or not. This is useful when you want to skip checks since the code didn't change. By default, it is **true**.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1379,8 +1379,8 @@ In addition, it is possible to specify this optional input:
 
 - **MAVEN_USER_HOME**: The path to Maven directory. By default, it is **./m2**.
 - **EXTRA_MAVEN_ARGS**: Additional arguments for Maven. By default, it is **""**.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 It then outputs this variable:
 
@@ -1436,8 +1436,8 @@ In addition, it is possible to specify these optional inputs:
 - **DOTNET_IMAGE_ENV_VARIABLES**: The environment variables to set when running the .NET docker image.
 - **CSHARPIER_VERSION**: The version of the CSharpier tool to use. For the default value, see the `dotnet/format` action.
 - **RUN_LINT**: Whatever or not the lint command should be executed. By default, it is **true**.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1481,8 +1481,8 @@ It requires these inputs:
 
 In addition, it is possible to specify these optional inputs:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 - **REGISTRY_URL**: The registry url where to push the Docker image. By default, it is **ghcr.io**.
 - **REGISTRY_USER**: The registry url where to push the Docker image.
   By default, it is the GitHub variable **github.actor**, the user who started the workflow. If you need a different user, remember to override the **GITHUB_TOKEN** secret.
@@ -1533,7 +1533,7 @@ It requires these inputs:
   Docker compose file and as value the name of the images that will be downloaded from the registry.
   You can retrieve dynamically the image name from the _docker build and push step_ by adding the step's name to the **needs** array of the workflow
   and using `${{ needs.{STEP_NAME}.outputs.DOCKER_IMAGE_NAME }}` where STEP_NAME is the step's name.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**. If the runner has no group, set it to **''**.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**. If the runner has no group, set it to **''**.
 
 This is an example to show how data should be formatted.
 
@@ -1580,8 +1580,8 @@ It also requires these secrets:
 
 In addition, it is possible to specify these optional inputs:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 - **DRY_RUN**: Only for tagged images, it shows which ones will be deleted without deleting them. By default, it is **false**.
 
 This is an example to show how data should be formatted.
@@ -1620,8 +1620,8 @@ It also requires these secrets:
 
 In addition, it is possible to specify this optional inputs:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1724,8 +1724,8 @@ It requires these secrets:
 
 In addition, it is possible to specify this optional inputs:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 - **DIND_IMAGE**: Docker image to use. Default is docker:26.0.0-dind.
 
 This is an example to show how data should be formatted.
@@ -1756,8 +1756,8 @@ It requires these secrets:
 
 In addition, it is possible to specify this optional inputs:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 - **DIND_IMAGE**: Docker image to use. Default is docker:26.0.0-dind.
 - **ISSUE_TYPE**: The type of the issue to create. Default is Task.
 - **ISSUE_DESCRIPTION**: The description of the issue to create. Default is "Created automatically via GitHub Actions".
@@ -1785,8 +1785,8 @@ jobs:
 
 It is possible to specify this optional input:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1809,8 +1809,8 @@ It requires these secrets:
 
 In addition, it is possible to specify this optional input:
 
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1849,8 +1849,8 @@ In addition, it is possible to specify these optional inputs:
 - **SONAR_IMAGE**: The Sonarqube docker image where the runner execute all commands. By default, it is **sonarsource/sonar-scanner-cli**.
 - **DOWNLOAD_ARTIFACT**: Whether it should download an artifact or not to analyze. By default, it is **true**.
 - **ARTIFACT_FILENAME**: The name of the artifact. By default, it is an empty string.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 
@@ -1907,8 +1907,8 @@ In addition, it is possible to specify these optional inputs:
 - **SONAR_EXCLUSIONS**: A comma separated list of glob patterns to match files and/or folders that should be excluded from Sonarqube analysis. You can't use a `sonar-project.properties` file since it's [not supported](https://community.sonarsource.com/t/configure-net-core-analysis-with-configuration-file/41299/2) from SonarScanner for .NET.
 - **COVERAGE_EXCLUSIONS**: A comma separated list of glob patterns to match files and/or folders that should be excluded when computing tests code coverage ([docs](https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md#source-files)). Since `dotnet test` expect absolute path for the exclusion list, you should provide this parameter in the form `**/my-path/*.cs` (always starting with `**/*`).
 - **DOTNET_VERSION**: The .NET version to build the solution. By default, it is `7`.
-- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is **zupit-agents**.
-- **RUNNERS_CONTAINER_GROUP**: The runners group used to execute this workflow. Default is **Container**.
+- **RUN_ON**: the _label_ to select the correct _github-runner_ that will execute this workflow. Default is a WarpBuild label; see the workflow's `RUN_ON` input for the exact SKU.
+- **RUNNERS_CONTAINER_GROUP**: Unused - every job runs on WarpBuild, which is selected by label alone. Kept so existing callers don't break. Default is **Container**.
 
 This is an example to show how data should be formatted.
 

--- a/docs/RUNNER_STRATEGY.md
+++ b/docs/RUNNER_STRATEGY.md
@@ -1,36 +1,80 @@
-# Runner strategy: WarpBuild vs self-hosted (`zupit-agents`)
+# Runner strategy: WarpBuild
 
-How reusable workflows in this repo choose a runner, and the one wiring detail
-that is easy to get wrong.
+How reusable workflows in this repo choose a runner.
 
 ## TL;DR
 
-- **Two runner backends** are used side by side:
-    - **`zupit-agents`** — our free self-hosted pool (runner group `Container`).
-    - **WarpBuild** — on-demand cloud runners (`warp-ubuntu-latest-<arch>-<size>`),
-      billed **per minute, 1-minute minimum**.
-- **Cheap, sub-minute jobs run on `zupit-agents`.** A 5–20s gate job billed a
-  full WarpBuild minute is pure waste, so those go to the self-hosted pool.
-- **Heavy jobs (build / lint / test / sonar-analyze / docker build) run on
-  WarpBuild**, sized per workload.
-- **The `runs-on:` wiring is different for the two backends.** Getting it wrong
-  silently sends a job to the wrong pool (or leaves it unschedulable). See the
-  gotcha below.
+- **Every job runs on WarpBuild** — on-demand cloud runners
+  (`warp-ubuntu-latest-<arch>-<size>`), billed per minute with a 1-minute
+  minimum.
+- **`runs-on:` is always a flat single label**, driven by an input:
+  `runs-on: ${{ inputs.RUN_ON }}`.
+- **Size the runner per workload.** Cheap gate jobs default to
+  `warp-ubuntu-latest-arm64-2x`; build / lint / test / analyze jobs default to a
+  larger x64 or arm64 SKU. All defaults are overridable per call.
+- The self-hosted `zupit-agents` pool is **not used** by these templates. If you
+  are considering it again, read [the appendix](#appendix-the-self-hosted-zupit-agents-detour)
+  first — it costs more than the label change.
 
-## Why the split exists
+## Input convention
 
-WarpBuild charges a **1-minute minimum per job**. The pipelines fan out into
-many tiny orchestration/gate jobs — `workdir-has-changes` (~20s), `jobs-succeded`
-(~5s), `jira-*`, `conventional-commits` lint (~9s), tag/version helpers — that
-run hundreds of times a week. Each one billed a full minute dwarfs its real
-cost. Those jobs are CPU-trivial, so they belong on the free self-hosted pool.
+| Input                     | Drives                                                                        | Default                       |
+| ------------------------- | ----------------------------------------------------------------------------- | ----------------------------- |
+| `RUN_ON`                  | cheap jobs: `workdir-has-changes`, `jobs-succeded`, jira, commit-lint, deploy | `warp-ubuntu-latest-arm64-2x` |
+| `RUN_ON_BUILD`            | build / compile / bundle jobs                                                 | larger WarpBuild SKU          |
+| `RUN_ON_LINT`             | lint jobs                                                                     | larger WarpBuild SKU          |
+| `RUN_ON_ANALYZE`          | sonar-analyze job                                                             | larger WarpBuild SKU          |
+| `RUNNERS_CONTAINER_GROUP` | **unused** — legacy input, kept so existing callers don't break               | `Container`                   |
 
-The heavy jobs (compile, bundle, sonar scan, docker build) genuinely need cores
-and are not sub-minute, so they stay on WarpBuild where we can size them.
+All inputs are `required: false` with a default — **a caller can override any of
+them per call.** Consumers that don't pass anything inherit these defaults, so a
+default change here propagates to every repo on this branch.
 
-## The gotcha: `runs-on:` wiring differs by backend
+## Choosing arch and size
 
-**Self-hosted `zupit-agents`** must be targeted with the **labels + group** block:
+- **arm64 is the cheaper flavor** and is the default wherever the job is
+  arch-safe (shell, git, node, dotnet). Prefer it.
+- **x64 is required** when the job produces or consumes an amd64 artifact, or
+  when a JS action / container image has no arm64 build. Two known cases:
+    - **Docker image builds** use plain `docker build` (no `--platform`), so the
+      image arch follows the runner arch. Images that must be `linux/amd64`
+      (e.g. a Keycloak image bundling an amd64 `promtail` binary) stay on x64.
+      An arm64 runner silently produces a broken image.
+    - **glibc-only tool images** — `mcr.microsoft.com/azure-cli` must be the
+      `azurelinux`/glibc tag, not alpine, or the bundled JS actions fail to run
+      on arm64.
+- **Size from real data, not intuition.** `tools/warpbuild-analysis/` turns a
+  WarpBuild usage export into per-`(workflow, job, sku)` upgrade / downgrade /
+  keep recommendations with CPU and memory p95s.
+
+## Checklist when adding or moving a job
+
+- **Flat `runs-on: ${{ inputs.RUN_ON* }}`** — never the `labels:` + `group:`
+  block; that form only targets self-hosted runner groups and will leave the job
+  unschedulable on WarpBuild.
+- **Arch-safe?** → arm64. **Produces amd64 artifacts / needs a glibc-only
+  image?** → x64.
+- **Needs a toolchain?** → either a `container:` image that ships it or the
+  matching `actions/setup-*` step. Both work on WarpBuild; the setup actions can
+  write the tool cache here.
+- **Sub-minute job?** It still costs a full minute. That is accepted — see the
+  appendix for why chasing it was not worth it.
+
+## Appendix: the self-hosted `zupit-agents` detour
+
+For a period the cheap sub-minute jobs (`workdir-has-changes` ~20s,
+`jobs-succeded` ~5s, `jira-*`, `conventional-commits` lint ~9s) were pointed at
+the free self-hosted `zupit-agents` pool to dodge WarpBuild's 1-minute minimum.
+That has been reverted; everything is back on WarpBuild. Keeping the notes here
+because the wiring is non-obvious and the next person to try will hit the same
+walls.
+
+Targeting the self-hosted pool takes **two** coordinated changes, and doing only
+one leaves the job unschedulable:
+
+1. the label default (`RUN_ON: "zupit-agents"`), **and**
+2. the grouped `runs-on:` form — those runners live in the `Container` runner
+   group and a bare `runs-on: zupit-agents` does not reliably reach them:
 
 ```yaml
 runs-on:
@@ -38,110 +82,22 @@ runs-on:
     group: ${{ inputs.RUNNERS_CONTAINER_GROUP }} # Container
 ```
 
-**WarpBuild** is targeted with a **flat single label**:
-
-```yaml
-runs-on: ${{ inputs.RUN_ON_BUILD }} # e.g. warp-ubuntu-latest-x64-4x
-```
-
-> A bare `runs-on: zupit-agents` (label only, no `group:`) does **not** reliably
-> reach the self-hosted pool — those runners live in the `Container` group and
-> are selected with the `labels`+`group` form. `main` has always used the
-> grouped form; a WarpBuild migration that flattens every `runs-on:` to a single
-> label will break self-hosted scheduling for the cheap jobs. When moving a job
-> back to `zupit-agents`, restore the grouped block **and** set the label
-> default — doing only one is not enough.
-
-## Second gotcha: self-hosted jobs must run in a `container:`
-
-The `zupit-agents` runners execute jobs as a non-root user that **cannot write to
-the runner's tool cache** (`/opt/github-runner/.../_work/_tool`). A job that runs
-directly on the host and tries to provision a toolchain fails, e.g.:
+On top of that, **every** self-hosted job needs a `container:`. The runners
+execute jobs as a non-root user that cannot write the runner's tool cache, so
+any `actions/setup-*` step fails on the host:
 
 ```
 EACCES: permission denied, mkdir '/opt/github-runner/.../_work/_tool/node/24.18.0'
 ```
 
-(`actions/setup-node` was the trigger; `setup-dotnet` / any tool-cache install
-behaves the same.) This is why **every** self-hosted job in these templates
-declares a `container:` — inside the container the steps run as root, so tool
-installs and the checkout's git work. Pick the image by what the job needs:
+Inside a container the steps run as root, so tool installs and the checkout's
+git work. That constraint drove a set of per-job workarounds — `container:
+node:24` instead of `actions/setup-node`, `container: buildpack-deps:24.04-scm`
+plus an `apt-get install jq` step for git/jq jobs, and jobs needing the `gh` CLI
+had to stay on WarpBuild because `gh` is not in the standard images. Docker
+builds also could not move: they need privileged docker-in-docker and an amd64
+host.
 
-```yaml
-runs-on:
-    labels: ${{ inputs.RUN_ON }}
-    group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
-container: buildpack-deps:24.04-scm # git + perl + curl; add `apt-get install jq` if needed
-# container: node:24                 # for a Node job — node + npm + git preinstalled, drop setup-node
-```
-
-Rules of thumb:
-
-- **Node job** → `container: node:24` and delete the `actions/setup-node` step
-  (the image already has the right Node).
-- **git-only job** (checkout, diff, tag, push) → `container: buildpack-deps:24.04-scm`.
-- **needs `jq`/other apt pkg** → same image + a step
-  `apt-get update && apt-get install -y --no-install-recommends <pkg>` (`perl` is
-  already present via `perl-base`).
-- **needs `gh` CLI** → `gh` is _not_ in the standard images and adding its apt repo
-  is fragile; for a low-frequency job it is not worth it — leave that job on
-  WarpBuild (github-hosted-style, `gh` preinstalled).
-
-## Input convention
-
-| Input                     | Drives                                                                        | Default (cheap→self-hosted / heavy→WarpBuild) | `runs-on:` form    |
-| ------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------- | ------------------ |
-| `RUN_ON`                  | cheap jobs: `workdir-has-changes`, `jobs-succeded`, jira, commit-lint, deploy | `zupit-agents`                                | labels + group     |
-| `RUNNERS_CONTAINER_GROUP` | runner group for the self-hosted jobs                                         | `Container`                                   | (used as `group:`) |
-| `RUN_ON_BUILD`            | build / compile / bundle jobs                                                 | WarpBuild string                              | flat label         |
-| `RUN_ON_LINT`             | lint jobs                                                                     | WarpBuild string                              | flat label         |
-| `RUN_ON_ANALYZE`          | sonar-analyze job                                                             | WarpBuild string                              | flat label         |
-
-All inputs are `required: false` with a default — **a caller can override any of
-them per call.** Consumers that don't pass anything inherit these defaults, so a
-default change here propagates to every repo on this branch.
-
-## Which jobs go where
-
-- **Self-hosted (`RUN_ON`, grouped):** the gate/orchestration jobs in the
-  `*-workflow-common` files, the `workdir-has-changes` + `jobs-succeded` jobs in
-  the `sonar-step-*-analyze` files, the `jira-*` and `conventional-commits-step-*`
-  workflows, `docker-step-delete-images`, and the deploy jobs in the
-  `*-build-and-deploy` / `azure-webapp-code-deploy` workflows (CPU-light, and
-  free self-hosted beats paying WarpBuild for a multi-minute deploy).
-- **WarpBuild (`RUN_ON_BUILD` / `RUN_ON_LINT` / `RUN_ON_ANALYZE`, flat):** the
-  build / lint / test / cypress / sonar-analyze jobs, plus **all docker image
-  builds** (`docker-step-build-and-push-image*`, `springboot-step-docker-*`,
-  `node-step-docker-*`).
-
-### Docker builds stay on WarpBuild
-
-Two reasons, both hard blockers for the self-hosted `Container` runners:
-
-1. **Privileged docker-in-docker** — the build job runs a DinD container with
-   `--privileged`; the self-hosted runners are not guaranteed to support that.
-2. **Architecture** — the builds use plain `docker build` (no `--platform`), so
-   the image arch follows the runner arch. They must produce `linux/amd64`
-   images (e.g. the Keycloak image bundles an amd64 `promtail` binary), so they
-   stay on x64 WarpBuild. An arm64 runner would silently produce a broken image.
-
-## Checklist when adding or moving a job
-
-- **Sub-minute + CPU-light?** → `zupit-agents`, grouped `runs-on:` (labels+group).
-- **Heavy / not sub-minute?** → WarpBuild via `RUN_ON_BUILD`/`_LINT`/`_ANALYZE`,
-  flat `runs-on:`.
-- **Polls or waits** (e.g. a migrator-trigger that retries, or a long deploy)? It
-  is _not_ sub-minute — judge by real p90, not by CPU. Keep long pollers on
-  WarpBuild.
-- **Needs docker/privileged?** → WarpBuild (see above).
-- **Runs directly on the host (no `container:`)?** Confirm the self-hosted
-  runners have the tools it calls (`git`, `gh`, `node`, …); the `Container` group
-  name refers to the runner group, not to auto-provisioned tooling.
-
-## How the target list was derived
-
-Job durations came from a jobs-usage CSV export (per `workflow / job` with
-`run_count`, `success_rate`, `duration_p75/p90` in **seconds**). "Sub-minute" =
-`duration_p90 < 60`. The highest-volume offenders are `jobs-succeded` (~5s) and
-`workdir-has-changes` (~20s), which recur in almost every pipeline — those are
-where the 1-minute-floor savings are largest.
+Net: the savings were confined to jobs measured in seconds, while every one of
+them acquired an image pin and a bespoke tool-install step. The flat WarpBuild
+label is the simpler default.


### PR DESCRIPTION
## What

Puts every job in these reusable workflows back on WarpBuild. Reverts the two commits that pointed the cheap sub-minute jobs at the self-hosted `zupit-agents` pool:

- `556cad8` — `ci: default cheap-job RUN_ON to zupit-agents to skip warpbuild 1min floor` (18 files, `RUN_ON` default)
- `557d706` — `fix: wire cheap jobs to zupit-agents via runner group (labels+group)` (same 18 files, `runs-on:` shape)

Base is `chore/warpbuild-and-action-bumps`, the branch consumers actually pin.

## Both commits have to go, not just one

They are a matched pair. The label alone does not select a self-hosted runner (those live in the `Container` runner group), so `556cad8` set the default and `557d706` switched `runs-on:` from a flat label to the grouped form:

```yaml
# before this PR
runs-on:
    labels: ${{ inputs.RUN_ON }} # zupit-agents
    group: ${{ inputs.RUNNERS_CONTAINER_GROUP }} # Container

# after this PR
runs-on: ${{ inputs.RUN_ON }} # warp-ubuntu-latest-arm64-2x
```

Reverting only the default would leave `{labels: warp-…, group: Container}`, which matches no WarpBuild runner and leaves those jobs unschedulable. Reverting only the shape would send them to a self-hosted pool by bare label, which is exactly the unreliable form `557d706` was fixing.

Checked that the grouped form was introduced by `557d706` and nothing else: before `556cad8`, `git grep -l 'group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}' -- .github/workflows/` returns nothing. After this PR it returns nothing again, and `grep -rn zupit-agents .github/` is empty.

## Not changed

- **`container:` declarations on the cheap jobs** (`buildpack-deps:24.04-scm` on `workdir-has-changes`, etc.) predate the `zupit-agents` move — they are context lines in `557d706`, not additions. They work fine on WarpBuild, so they stay.
- **`RUNNERS_CONTAINER_GROUP` input** stays declared on all 30 workflows that had it. It was already declared-but-unused before `556cad8`; removing it would break callers that pass it. Now documented as unused.
- **Runner SKUs and the `RUN_ON_BUILD` / `RUN_ON_LINT` / `RUN_ON_ANALYZE` defaults** — untouched, this PR only undoes the self-hosted detour.

## Docs

- `docs/RUNNER_STRATEGY.md` described the two-backend split as current, which it no longer is. Rewritten as WarpBuild-only: input convention, how to pick arch and size, and the flat-`runs-on:` rule. The self-hosted knowledge is kept in an appendix (grouped `runs-on:` form, the tool-cache `EACCES` that forces `container:` on every self-hosted job, why `gh`-CLI and docker-build jobs could never move) so the next person to consider that pool sees the real cost up front rather than rediscovering it.
- `README.md` said `RUN_ON` defaults to `zupit-agents` in 17 places plus one YAML snippet. That text was already stale — the original WarpBuild migration never updated it — but this PR is what makes the `RUNNERS_CONTAINER_GROUP` line wrong too, so both are corrected: `RUN_ON` now points at the workflow's own default, and `RUNNERS_CONTAINER_GROUP` is marked unused-but-kept.

## Checks

- All workflow files parse as valid YAML.
- `prettier --check` passes on the touched markdown (verified on LF-normalized copies; a Windows CRLF checkout makes local `npm run format` rewrite the whole repo, which is a pre-existing local-only artifact).

## Companion PR

zupit-it/provisus#1596 does the same for the five jobs pinned directly in that repo's own workflows. All checks green there, including `migration-history-check` running on `warp-ubuntu-latest-arm64-2x` with the .NET SDK container.
